### PR TITLE
Add ability to deregister response handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Of cource, Socket.IO's `emit` and `on` have request-response. This library adds 
 ## Methods
 
 - `request("method", data)` return `Promise`
-- `response("method", handler)`
+- `response("method", handler)` return `function` which deregisters handler when called
 
 
 ## Usage

--- a/src/index.es6
+++ b/src/index.es6
@@ -42,7 +42,8 @@ class SocketIORequest{
   response(method, callback){
     if(typeof method !== "string") throw new Error('argument "method" is missing');
     if(typeof callback !== "function") throw new Error('"callback" must be a function');
-    this.io.on(this.options.event, (req, ack) => {
+
+    const listener = (req, ack) => {
       if(req.method !== method) return;
       const res = function(data){
         ack({data});
@@ -51,7 +52,12 @@ class SocketIORequest{
         ack({error: convertErrorToObject(err)});
       };
       callback(req.data, res);
-    });
+    };
+
+    this.io.on(this.options.event, listener);
+    return () => {
+      this.io.removeListener(this.options.event, listener);
+    };
   }
 
 }

--- a/test/remove_response_handler.es6
+++ b/test/remove_response_handler.es6
@@ -1,0 +1,47 @@
+/* eslint-env mocha */
+
+import { assert } from "chai";
+import { Server, port } from "./helper";
+
+import Client from "socket.io-client";
+
+import ioreq from "../";
+
+const server = Server();
+
+describe("response method", function () {
+  it("should return function allowing to remove response handler", function (done) {
+    this.timeout(2000);
+
+    let removeHandler;
+    server.on("connection", (socket) => {
+      removeHandler = ioreq(socket).response("toUpper", (req, res) => {
+        res(req.str.toUpperCase());
+      });
+
+      assert.equal(typeof removeHandler, 'function');
+    });
+
+    const client = Client(`http://localhost:${port}`);
+    client.once("connect", async () => {
+      const io = ioreq(client, { timeout: 1000 });
+
+      const str1 = await io.request("toUpper", { str: "hello" });
+      assert.equal(str1, "HELLO");
+
+      removeHandler();
+
+      let str2, err;
+      try {
+        str2 = await io.request("toUpper", { str: "i should fail" });
+      }
+      catch (_err) {
+        err = _err;
+      }
+
+      assert.isUndefined(str2);
+      assert.equal(err.name, "TimeoutError");
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Hi :)
I needed such feature in my app and decided to create a pull request.

It makes `ioreq.response('method', handler)` return a deregister function which when called will cleanup this response handler. I updated README.md and also created test for this feature. 